### PR TITLE
feat : 약속 생성, 약속 단일 조회, 약속 목록 조회 API 개발 완료

### DIFF
--- a/backend/src/main/java/com/example/tomo/Moim/MoimRepository.java
+++ b/backend/src/main/java/com/example/tomo/Moim/MoimRepository.java
@@ -11,4 +11,5 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
     Boolean existsByMoimName(String moimName);
 
 
+
 }

--- a/backend/src/main/java/com/example/tomo/Promise/Promise.java
+++ b/backend/src/main/java/com/example/tomo/Promise/Promise.java
@@ -4,7 +4,10 @@ import com.example.tomo.Moim.Moim;
 import jakarta.persistence.*;
 import lombok.Getter;
 
+import java.sql.Time;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -21,6 +24,22 @@ public class Promise {
 
     private String place;
 
-    private LocalDateTime time;
+    private LocalTime promiseTime;
+    private LocalDate promiseDate;
+    private String promiseName;
+
+    public Promise() {}
+
+    public Promise(String promiseName, String place,
+                   LocalTime promiseTime, LocalDate promiseDate) {
+        this.place = place;
+        this.promiseName = promiseName;
+        this.promiseDate = promiseDate;
+        this.promiseTime = promiseTime;
+    }
+
+    public void setMoimBasedPromise(Moim moim){
+        this.moim = moim;
+    }
 
 }

--- a/backend/src/main/java/com/example/tomo/Promise/PromiseController.java
+++ b/backend/src/main/java/com/example/tomo/Promise/PromiseController.java
@@ -1,0 +1,32 @@
+package com.example.tomo.Promise;
+
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+public class PromiseController {
+
+    private final PromiseService promiseService;
+
+    public PromiseController(PromiseService promiseService) {
+        this.promiseService = promiseService;
+    }
+
+    @PostMapping("/promises")
+    public Long addPromise(@RequestBody addPromiseRequestDTO dto) {
+        return promiseService.addPromise(dto);
+
+    }
+
+    @GetMapping("/promises/{promise_id}")
+    public ResponseGetPromiseDto getPromise(@PathVariable Long promise_id){
+        return promiseService.getPromise(promise_id);
+    }
+
+    @GetMapping("/promises")
+    public List<ResponseGetPromiseDto> getAllPromises(@RequestParam Long moim_id){
+        return promiseService.getAllPromise(moim_id);
+
+    }
+}

--- a/backend/src/main/java/com/example/tomo/Promise/PromiseRepository.java
+++ b/backend/src/main/java/com/example/tomo/Promise/PromiseRepository.java
@@ -1,0 +1,24 @@
+package com.example.tomo.Promise;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Time;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Date;
+import java.util.List;
+
+@Repository
+public interface PromiseRepository extends JpaRepository<Promise, Long> {
+
+    boolean existsByPromiseName(String name);
+    boolean existsByPromiseDateAndPromiseTime( LocalDate date,LocalTime time);
+
+    @Query("SELECT new com.example.tomo.Promise.ResponseGetPromiseDto(p.promiseName, p.promiseDate, p.promiseTime, p.place" +
+            ") FROM Promise p WHERE p.moim.id =:moim_id")
+    List<ResponseGetPromiseDto> findByMoimId(@Param("moim_id") Long moim_id);
+}

--- a/backend/src/main/java/com/example/tomo/Promise/PromiseService.java
+++ b/backend/src/main/java/com/example/tomo/Promise/PromiseService.java
@@ -1,0 +1,52 @@
+package com.example.tomo.Promise;
+
+import com.example.tomo.Moim.Moim;
+import com.example.tomo.Moim.MoimRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class PromiseService {
+
+    private final PromiseRepository promiseRepository;
+    private final MoimRepository moimRepository;
+
+    public PromiseService(PromiseRepository promiseRepository, MoimRepository moimRepository) {
+        this.promiseRepository = promiseRepository;
+        this.moimRepository = moimRepository;
+    }
+
+    // 약속 생성하기
+    // 같은 날짜 같은 시간에 약속 존재 시에도 오류 발생
+    public Long addPromise(addPromiseRequestDTO dto){
+
+         if(promiseRepository.existsByPromiseName(dto.getPromiseName()) &&
+                 promiseRepository.existsByPromiseDateAndPromiseTime(dto.getPromiseDate(),dto.getPromiseTime())) {
+             throw new RuntimeException("Promise already exists");
+         }
+
+         Promise promise = new Promise(dto.getPromiseName(),dto.getPlace(),
+                dto.getPromiseTime(),dto.getPromiseDate());
+
+         Moim moim = moimRepository.findById(dto.getMoimId()).orElseThrow(() -> new RuntimeException("모임 생성 후 약속을 만들어 주세요"));
+
+         promise.setMoimBasedPromise(moim);
+         return promiseRepository.save(promise).getId();
+    }
+
+    // 약속 단일 조회하기 promise_id
+    public ResponseGetPromiseDto getPromise(Long promiseId){
+        Promise promise = promiseRepository.findById(promiseId).orElseThrow(() -> new RuntimeException("존재하지 않는 약속입니다"));
+        return new ResponseGetPromiseDto(promise.getPromiseName(),promise.getPromiseDate(),
+        promise.getPromiseTime(),promise.getPlace());
+
+
+    }
+    public List<ResponseGetPromiseDto> getAllPromise(Long moimId){
+        return promiseRepository.findByMoimId(moimId);
+    }
+
+
+    // 약속 몰록 조회하기 moim_id, user_id
+}

--- a/backend/src/main/java/com/example/tomo/Promise/ResponseGetPromiseDto.java
+++ b/backend/src/main/java/com/example/tomo/Promise/ResponseGetPromiseDto.java
@@ -1,0 +1,22 @@
+package com.example.tomo.Promise;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseGetPromiseDto {
+
+    private String promiseName;
+    private LocalDate promiseDate;
+    private LocalTime promiseTime;
+    private String place;
+
+}

--- a/backend/src/main/java/com/example/tomo/Promise/addPromiseRequestDTO.java
+++ b/backend/src/main/java/com/example/tomo/Promise/addPromiseRequestDTO.java
@@ -1,0 +1,22 @@
+package com.example.tomo.Promise;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.sql.Time;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+public class addPromiseRequestDTO {
+
+    // 약속 엔티티에 약속명 추가히기
+    private Long moimId;
+    private String promiseName;
+    private LocalDate promiseDate;
+    private LocalTime promiseTime;
+    private String place;
+
+
+}


### PR DESCRIPTION
- 현재 약속 목록 조회와 , 약속 단일 조회 시 쿼리 파라미터 방식, @PathVariable 방식을 혼용 중
- 둘중에 어느 API가 더 큰 범위를 갖게 할 것인지에 대한 논의 필요


### 약속 생성 
<img width="1000" height="655" alt="image" src="https://github.com/user-attachments/assets/a615cc99-14b3-4621-9563-e7dbe255f32a" />

### 약속 단일 조회 
<img width="1000" height="655" alt="image" src="https://github.com/user-attachments/assets/c348f73a-6135-4164-9113-a648cac19a84" />

- 약속 단일 조회 시 @PathVariable 형식으로 promise_Id를 받아옴

### 약속 목록 조회
<img width="1000" height="786" alt="image" src="https://github.com/user-attachments/assets/7bf1d7f6-9b45-4c70-b1e1-68d159dd41df" />

- 약속 목록 조회시 쿼리 파라미터로 moim_id를 받음 
- 모임에 속한 모든 약속의 목록을 출력하는 용도