### PR TITLE
Backend/refactor/22

### DIFF
--- a/backend/src/main/java/com/example/tomo/Moim/MoimController.java
+++ b/backend/src/main/java/com/example/tomo/Moim/MoimController.java
@@ -1,6 +1,10 @@
 package com.example.tomo.Moim;
 
-import jakarta.servlet.http.HttpServletResponse;
+import com.example.tomo.Users.ResponseUniformDto;
+import com.example.tomo.global.DuplicatedException;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,16 +21,33 @@ public class MoimController {
 
     }
 
+    // 모임 생성하기
     @PostMapping("/moims")
-    public Long moim(@RequestBody addMoimRequestDto dto) {
-        return moimService.addMoim(dto);
+    public ResponseEntity<ResponseUniformDto> addmoim(@RequestBody addMoimRequestDto dto) {
+
+       try{
+           return ResponseEntity.ok(moimService.addMoim(dto));
+       }
+       catch(EntityNotFoundException e){
+           return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                   new ResponseUniformDto(false ,"존재하지 않은 사용자를 친구로 추가했습니다"));
+       }
+       catch(DuplicatedException e){
+           return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                   new ResponseUniformDto(false ,"이미 존재하는 모임입니다."));
+       }
+
+
     }
 
+    // 모임 상세 조회하기
     @GetMapping("/moims/{id}")
     public getMoimResponseDTO moimGet(@PathVariable Long id) {
 
         return moimService.getMoim(id);
     }
+
+    // 사용자 ID에 해당하는 모임 정보 불러오기
     @GetMapping("moims")
     public List<getMoimResponseDTO> getAllMoims(@RequestParam Long user_id) {
         return moimService.getMoimList(user_id);

--- a/backend/src/main/java/com/example/tomo/Moim/MoimController.java
+++ b/backend/src/main/java/com/example/tomo/Moim/MoimController.java
@@ -1,13 +1,13 @@
 package com.example.tomo.Moim;
 
 import com.example.tomo.Users.ResponseUniformDto;
+import com.example.tomo.global.ApiResponse;
 import com.example.tomo.global.DuplicatedException;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 public class MoimController {
@@ -41,17 +41,22 @@ public class MoimController {
     }
 
     // 모임 상세 조회하기
-    @GetMapping("/moims/{id}")
-    public getMoimResponseDTO moimGet(@PathVariable Long id) {
+    @GetMapping("/moims")
+    public ResponseEntity<ApiResponse<getMoimResponseDTO>> moimGet(@RequestParam String moimName) {
 
-        return moimService.getMoim(id);
+        try{
+            return ResponseEntity.ok(ApiResponse.success(moimService.getMoim(moimName),"성공"));
+        }catch(EntityNotFoundException e){
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).
+                    body(ApiResponse.failure("존재하지 않는 모임입니다."));
+        }
     }
 
-    // 사용자 ID에 해당하는 모임 정보 불러오기
+    /*// 사용자 ID에 해당하는 모임 정보 불러오기
     @GetMapping("moims")
     public List<getMoimResponseDTO> getAllMoims(@RequestParam Long user_id) {
         return moimService.getMoimList(user_id);
-    }
+    }*/
 
 
 

--- a/backend/src/main/java/com/example/tomo/Moim/MoimController.java
+++ b/backend/src/main/java/com/example/tomo/Moim/MoimController.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @RestController
 public class MoimController {
@@ -52,11 +54,11 @@ public class MoimController {
         }
     }
 
-    /*// 사용자 ID에 해당하는 모임 정보 불러오기
-    @GetMapping("moims")
-    public List<getMoimResponseDTO> getAllMoims(@RequestParam Long user_id) {
-        return moimService.getMoimList(user_id);
-    }*/
+    // 사용자 ID에 해당하는 모임 정보 불러오기
+    @GetMapping("moims/mine")
+    public ResponseEntity<List<getMoimResponseDTO>> getAllMoims() {
+        return ResponseEntity.ok().body(moimService.getMoimList());
+    }
 
 
 

--- a/backend/src/main/java/com/example/tomo/Moim/MoimRepository.java
+++ b/backend/src/main/java/com/example/tomo/Moim/MoimRepository.java
@@ -3,12 +3,15 @@ package com.example.tomo.Moim;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MoimRepository extends JpaRepository<Moim, Long> {
     // 모임 생성하기
 
     // 모임명으로 이미 만들어진 모임인지 확인하기
     Boolean existsByMoimName(String moimName);
+    Optional<Moim> findByMoimName(String moimName);
 
 
 

--- a/backend/src/main/java/com/example/tomo/Moim/MoimRepository.java
+++ b/backend/src/main/java/com/example/tomo/Moim/MoimRepository.java
@@ -12,4 +12,5 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
 
 
 
+
 }

--- a/backend/src/main/java/com/example/tomo/Moim/MoimService.java
+++ b/backend/src/main/java/com/example/tomo/Moim/MoimService.java
@@ -2,21 +2,25 @@ package com.example.tomo.Moim;
 
 import com.example.tomo.Moim_people.MoimPeopleRepository;
 import com.example.tomo.Moim_people.Moim_people;
+import com.example.tomo.Users.ResponseUniformDto;
 import com.example.tomo.Users.User;
 import com.example.tomo.Users.UserRepository;
+import com.example.tomo.global.DuplicatedException;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class MoimService {
 
-    private MoimRepository moimRepository;
-    private UserRepository userRepository;
-    private MoimPeopleRepository moimPeopleRepository;
+    private final MoimRepository moimRepository;
+    private final UserRepository userRepository;
+    private final MoimPeopleRepository moimPeopleRepository;
 
     @Autowired
     public MoimService(MoimRepository moimRepository, UserRepository userRepository, MoimPeopleRepository moimPeopleRepository) {
@@ -26,23 +30,27 @@ public class MoimService {
     }
 
     @Transactional
-    public Long addMoim(addMoimRequestDto dto) {
+    public ResponseUniformDto addMoim(addMoimRequestDto dto) {
         if (moimRepository.existsByMoimName(dto.getMoimName())) {
-            throw new IllegalArgumentException("이미 존재하는 모임 이름입니다.");
+            throw new DuplicatedException("이미 존재하는 모임 이름입니다.");
         }
 
         Moim moim = new Moim(dto.getMoimName(), dto.getDescription());
-        System.out.println("moim.getMoimName()= " + moim.getMoimName() + " moim.getDescription ="
-        + moim.getDescription());
         moimRepository.save(moim);
 
-        List<User> users = userRepository.findAllById(dto.getUserIds());
-        for (User user : users) {
-            Moim_people moim_people = new Moim_people(moim, user);
+        for (String userName : dto.getUserNames()) {
+
+            Optional<User> user = userRepository.findByUsername(userName);
+
+            if(user.isEmpty()){
+                throw new EntityNotFoundException("해당 이름의 사용자가 존재하지 않습니다");
+            }
+
+            Moim_people moim_people = new Moim_people(moim, user.get());
             moimPeopleRepository.save(moim_people);
         }
 
-        return moim.getId();
+        return new ResponseUniformDto(true ,"모임 생성 완료 ");
     }
 
     // 모임 단일 조회

--- a/backend/src/main/java/com/example/tomo/Moim/MoimService.java
+++ b/backend/src/main/java/com/example/tomo/Moim/MoimService.java
@@ -55,9 +55,9 @@ public class MoimService {
 
     // 모임 단일 조회
     @Transactional
-    public getMoimResponseDTO getMoim(Long moim_id){
-         Moim moim= moimRepository.findById(moim_id).orElseThrow(
-                 () -> new IllegalArgumentException("moim not found")
+    public getMoimResponseDTO getMoim(String moimName) {
+         Moim moim= moimRepository.findByMoimName(moimName).orElseThrow(
+                 () -> new EntityNotFoundException("존재하지 않는 모임입니다")
          );
 
         return new getMoimResponseDTO(moim.getMoimName(), moim.getDescription(), moim.getMoimPeopleList().size());
@@ -65,12 +65,15 @@ public class MoimService {
     // 모임 상세 조회
 
     @Transactional
-    public List<getMoimResponseDTO> getMoimList(Long user_id){
-        List<Moim_people> moims = moimPeopleRepository.findByUserId(user_id);
+    public List<getMoimResponseDTO> getMoimList(){
+        // 액세스 토큰이 들어오면 처리할 파트
+        Long userId = 1L;
 
+        List<Moim_people> moims = moimPeopleRepository.findByUserId(userId);
         List<getMoimResponseDTO> moimResponseDTOList = new ArrayList<>();
+
         for(Moim_people moim_people : moims){
-            moimResponseDTOList.add(this.getMoim(moim_people.getMoim().getId()));
+            moimResponseDTOList.add(this.getMoim(moim_people.getMoim().getMoimName()));
         }
 
         return moimResponseDTOList;

--- a/backend/src/main/java/com/example/tomo/Moim/addMoimRequestDto.java
+++ b/backend/src/main/java/com/example/tomo/Moim/addMoimRequestDto.java
@@ -11,5 +11,5 @@ public class addMoimRequestDto {
 
     private String moimName;
     private String description;
-    private List<Long> userIds;
+    private List<String> userNames;
 }

--- a/backend/src/main/java/com/example/tomo/Users/UserRepository.java
+++ b/backend/src/main/java/com/example/tomo/Users/UserRepository.java
@@ -3,14 +3,15 @@ package com.example.tomo.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+
 import java.util.Optional;
 
 @Repository
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findById(Long id);
 
     Optional<User> findByEmail(String email);
     Optional<User> findByFirebaseId(String firebaseId);
+    Optional<User> findByUsername(String username);
 }

--- a/backend/src/main/java/com/example/tomo/global/ApiResponse.java
+++ b/backend/src/main/java/com/example/tomo/global/ApiResponse.java
@@ -1,0 +1,29 @@
+package com.example.tomo.global;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private boolean success;
+    private String message;
+    private T data;
+
+    // 성공 응답 생성용
+    public static <T> ApiResponse<T> success(T data, String message) {
+        return new ApiResponse<>(true, message, data);
+    }
+
+    // 실패 응답 생성용
+    public static <T> ApiResponse<T> failure(String message) {
+        return new ApiResponse<>(false, message, null);
+    }
+}

--- a/backend/src/main/java/com/example/tomo/global/DuplicatedException.java
+++ b/backend/src/main/java/com/example/tomo/global/DuplicatedException.java
@@ -1,0 +1,7 @@
+package com.example.tomo.global;
+
+public class DuplicatedException extends RuntimeException {
+    public DuplicatedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
- 예외에 따른 적절한 상태코드를 내보내도록 수정 
- 서로 다른 반환 타입의 DTO에 대한 통합된 Response를 내보내기 위한 ApiResponse 클래스 추가
- 가독성 있게 엔드포인트 재구성

## 모임 생성
### 생성 성공 200 반환
<img width="875" height="449" alt="image" src="https://github.com/user-attachments/assets/50b2e293-12c9-40b0-b130-650273de3b2c" />


### 생성 실패 409 반환
<img width="875" height="449" alt="image" src="https://github.com/user-attachments/assets/1e123e1d-58c7-46b6-b1c2-52a29901cf31" />

## 모임 단일 조회
- 모임 조회시 모임명을 통해서 조회함 
- 응답 타입이 API 호출 성공여부, 메시지, 응답DTO의 형식으로 구성, 나중에 추가적으로 회의를 통해서 응답 포맷을 정해도 될듯
<img width="899" height="563" alt="image" src="https://github.com/user-attachments/assets/9729535e-095f-45c7-9b63-a8de55fc403a" />

## 모임 목록 조회
- 본인이 참여하고 있는 모임을 조회

<img width="899" height="687" alt="image" src="https://github.com/user-attachments/assets/de1dc770-4b9b-499a-9c23-b799815ac41b" />


