### PR TITLE
feat - 토큰 변환 API 세팅 및 친구추가, 조회 API 연동

### DIFF
--- a/frontend/app/build.gradle.kts
+++ b/frontend/app/build.gradle.kts
@@ -92,6 +92,13 @@ dependencies {
     // Coil for image loading
     implementation(libs.coil.compose)
 
+    // Security Crypto for encrypted shared preferences
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
+    implementation("com.squareup.retrofit2:converter-scalars:2.9.0")
+
+    // OkHttp for HTTP client
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/frontend/app/build.gradle.kts
+++ b/frontend/app/build.gradle.kts
@@ -98,6 +98,7 @@ dependencies {
 
     // OkHttp for HTTP client
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/frontend/app/src/main/AndroidManifest.xml
+++ b/frontend/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.TomoAndroid">

--- a/frontend/app/src/main/java/com/markoala/tomoandroid/MainActivity.kt
+++ b/frontend/app/src/main/java/com/markoala/tomoandroid/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -21,6 +22,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
 
         AuthManager.init()
+        AuthManager.initTokenManager(this)
 
         setContent {
             TomoAndroidTheme {
@@ -33,14 +35,15 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun MainScreen() {
     var signedIn by remember { mutableStateOf(false) }
-//    val context = LocalContext.current
-//    val scope = rememberCoroutineScope()
     val navController = rememberNavController()
+
+    // 앱 시작 시 저장된 토큰 확인
+    LaunchedEffect(Unit) {
+        signedIn = AuthManager.hasValidTokens()
+    }
 
     ToastProvider {
         // 로그인/로그아웃 시 signedIn 상태 변경
         AppNavHost(navController = navController, isSignedIn = signedIn)
     }
-
-    // 로그인 성공/실패 콜백을 NavHost에서 처리하므로 아래 기존 UI는 제거
 }

--- a/frontend/app/src/main/java/com/markoala/tomoandroid/auth/AuthManager.kt
+++ b/frontend/app/src/main/java/com/markoala/tomoandroid/auth/AuthManager.kt
@@ -9,39 +9,116 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
+import com.markoala.tomoandroid.data.api.apiService
+import com.markoala.tomoandroid.utils.auth.TokenManager
+import kotlinx.coroutines.tasks.await
 
-object AuthManager {
+object AuthManager { // 싱글톤 객체로 앱 전체에서 하나의 인스턴스만 사용
     private const val TAG = "AuthManager"
     lateinit var auth: FirebaseAuth
+    private var tokenManager: TokenManager? = null
 
-    fun init() {
+    fun init() { // 인스턴스 초기화
         auth = Firebase.auth
     }
 
-    fun firebaseAuthWithGoogle(idToken: String, onResult: (Boolean, String?) -> Unit) {
-        val credential = GoogleAuthProvider.getCredential(idToken, null)
-        auth.signInWithCredential(credential)
-            .addOnCompleteListener { task ->
-                if (task.isSuccessful) {
-                    val user = auth.currentUser
-                    user?.getIdToken(true)?.addOnCompleteListener { tokenTask ->
-                        if (tokenTask.isSuccessful) {
-                            val firebaseToken = tokenTask.result?.token
-                            Log.d(TAG, "Firebase ID Token: $firebaseToken")
-                        } else {
-                            Log.e(TAG, "토큰 가져오기 실패", tokenTask.exception)
-                        }
-                    }
-                    onResult(true, null)
-                } else {
-                    onResult(false, task.exception?.localizedMessage)
-                }
-            }
+    fun initTokenManager(context: Context) { // 토큰 매니저 초기화(Access, Refresh Token 저장소)
+        tokenManager = TokenManager(context)
     }
 
+    suspend fun firebaseAuthWithGoogle(
+        idToken: String,
+        context: Context,
+        onResult: (Boolean, String?) -> Unit
+    ) {
+        val credential = GoogleAuthProvider.getCredential(idToken, null) // 구글 ID 토큰
+        try {
+            val authResult = auth.signInWithCredential(credential).await() // 파베 인증
+            if (authResult.user != null) {
+                val user = auth.currentUser // 현재 인증된 사용자 정보
+                user?.let {
+                    // Firebase ID 토큰 가져오기
+                    val firebaseToken = it.getIdToken(true).await()?.token // 파베 Id 토큰 발급
+                    if (firebaseToken != null) {
+                        Log.d(TAG, "Firebase ID Token acquired")
+                        // 서버에서 access token과 refresh token 받아오기
+                        val success = exchangeFirebaseTokenForServerTokens(
+                            firebaseToken,
+                            context
+                        ) // Firebase IdToken -> 서버 Access, Refresh Token 교환
+                        onResult(success, null)
+                    } else {
+                        Log.e(TAG, "Firebase ID 토큰 가져오기 실패")
+                        onResult(false, "Firebase ID 토큰 가져오기 실패")
+                    }
+                }
+            } else {
+                onResult(false, "로그인 실패")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Firebase 인증 실패", e)
+            onResult(false, e.localizedMessage)
+        }
+    }
+
+    private suspend fun exchangeFirebaseTokenForServerTokens( // Firebase IdToken -> 서버 Access, Refresh Token 교환
+        firebaseToken: String,
+        context: Context
+    ): Boolean {
+        return try {
+            if (tokenManager == null) { // 토큰매니저가 null이면 초기화
+                initTokenManager(context)
+            }
+
+            val response = apiService.getTokensWithFirebaseToken("Bearer $firebaseToken") // 서버에 요청
+
+            if (response.isSuccessful) {
+                // 헤더에서 토큰 추출
+                val accessToken = response.headers()["Authorization"] // 응답 헤더의 Authorization 부분 추출
+                val refreshToken = response.headers()["Refresh-Token"] // 응답 헤더의 refresh-token 부분 추출
+
+                if (accessToken != null && refreshToken != null) {
+                    // "Bearer " 제거
+                    val cleanAccessToken = accessToken.removePrefix("Bearer ") // Bearer 부분 제거
+
+                    // 토큰 저장
+                    tokenManager?.saveTokens(
+                        cleanAccessToken,
+                        refreshToken
+                    ) // access, refresh token 저장
+                    Log.d(TAG, "토큰이 성공적으로 저장되었습니다")
+                    true
+                } else {
+                    Log.e(TAG, "응답 헤더에서 토큰을 찾을 수 없습니다")
+                    false
+                }
+            } else {
+                Log.e(TAG, "서버 토큰 교환 실패: ${response.code()}")
+                false
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "토큰 교환 중 오류 발생", e)
+            false
+        }
+    }
+
+    fun getStoredAccessToken(): String? {
+        return tokenManager?.getAccessToken()
+    }
+
+    fun getStoredRefreshToken(): String? {
+        return tokenManager?.getRefreshToken()
+    }
+
+    fun hasValidTokens(): Boolean {
+        return tokenManager?.hasValidTokens() == true
+    }
 
     suspend fun signOutSuspend(context: Context): Pair<Boolean, String?> {
         return try {
+            // 저장된 토큰 삭제
+            tokenManager?.clearTokens()
+
             if (::auth.isInitialized) auth.signOut()
             val credentialManager = CredentialManager.create(context)
             val clearRequest = ClearCredentialStateRequest()

--- a/frontend/app/src/main/java/com/markoala/tomoandroid/data/api/AuthInterceptor.kt
+++ b/frontend/app/src/main/java/com/markoala/tomoandroid/data/api/AuthInterceptor.kt
@@ -1,0 +1,31 @@
+package com.markoala.tomoandroid.data.api
+
+import com.markoala.tomoandroid.auth.AuthManager
+import okhttp3.Interceptor
+import okhttp3.Response
+
+// 모든 네트워크 요청에 자동으로 인증 토큰(Access Token)을 추가하기 위한 OkHttp의 인터셉터
+// Retrofit에서 API 요청을 보낼 때마다 매번 수동으로 Authorization 헤더를 붙이지 않아도 되는 역할
+class AuthInterceptor :
+    Interceptor { // Interceptor는 OkHttp의 기능(인터페이스)로 요청 혹은 응답을 가로채서 수정하거나 로그를 추가할 수 있음
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request() // 현재 전송될 원본 HTTP 요청을 가져옴
+
+        // 이미 Authorization 헤더가 있는 경우 그대로 진행 (Firebase 토큰 교환 시)
+        if (originalRequest.header("Authorization") != null) {
+            return chain.proceed(originalRequest)
+        }
+
+        // 저장된 access token 가져오기
+        val accessToken = AuthManager.getStoredAccessToken()
+
+        return if (accessToken != null) { // Authorization 헤더에 추가
+            val newRequest = originalRequest.newBuilder()
+                .addHeader("Authorization", "Bearer $accessToken")
+                .build()
+            chain.proceed(newRequest) // access token 있는 경우 헤더 붙여서 요청 진행
+        } else {
+            chain.proceed(originalRequest) // 없는 경우 원본 요청 진행
+        }
+    }
+}

--- a/frontend/app/src/main/java/com/markoala/tomoandroid/data/api/UserApiService.kt
+++ b/frontend/app/src/main/java/com/markoala/tomoandroid/data/api/UserApiService.kt
@@ -6,6 +6,7 @@ import com.markoala.tomoandroid.data.model.GetFriendsResponse
 import com.markoala.tomoandroid.data.model.PostResponse
 import com.markoala.tomoandroid.data.model.UserData
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.Retrofit
@@ -30,20 +31,25 @@ interface UserApiService {
     ): Response<String>
 
     // 친구 검색 API (AuthInterceptor가 자동으로 Authorization 헤더 추가)
-    @POST("/friends")
+    @POST("/public/friends")
     fun postFriends(
         @Body body: FriendSearchRequest
     ): Call<FriendSearchResponse>
 
-    @GET("/friends")
+    @GET("/public/friends")
     fun getFriends(
         @Query("email") email: String
     ): Call<GetFriendsResponse>
 }
 
+// HttpLoggingInterceptor 생성 및 설정
+private val loggingInterceptor = HttpLoggingInterceptor().apply {
+    level = HttpLoggingInterceptor.Level.BODY // 요청과 응답의 헤더 및 본문 모두 로깅
+}
 
 // AuthInterceptor를 포함한 OkHttpClient 생성
 private val okHttpClient = OkHttpClient.Builder()
+    .addInterceptor(loggingInterceptor) // 로깅 인터셉터 추가
     .addInterceptor(AuthInterceptor()) // 인터셉터(자동으로 헤더에 토큰 추가)
     .build()
 

--- a/frontend/app/src/main/java/com/markoala/tomoandroid/data/api/UserApiService.kt
+++ b/frontend/app/src/main/java/com/markoala/tomoandroid/data/api/UserApiService.kt
@@ -5,9 +5,12 @@ import com.markoala.tomoandroid.data.model.FriendSearchResponse
 import com.markoala.tomoandroid.data.model.GetFriendsResponse
 import com.markoala.tomoandroid.data.model.PostResponse
 import com.markoala.tomoandroid.data.model.UserData
+import okhttp3.OkHttpClient
 import retrofit2.Call
+import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -19,22 +22,36 @@ interface UserApiService {
     @POST("/sign")
     fun signup(@Body body: UserData): Call<PostResponse>
 
-    // 친구 검색 API
+    // Firebase ID 토큰으로 access token과 refresh token 받기
+    @GET("/api/protected/user")
+    suspend fun getTokensWithFirebaseToken(
+        @Header("Authorization") firebaseToken: String,
+        @Header("Content-Type") contentType: String = "application/json"
+    ): Response<String>
+
+    // 친구 검색 API (AuthInterceptor가 자동으로 Authorization 헤더 추가)
     @POST("/friends")
     fun postFriends(
-        @Header("Authorization") authorization: String,
         @Body body: FriendSearchRequest
     ): Call<FriendSearchResponse>
 
     @GET("/friends")
     fun getFriends(
-        @Header("Authorization") authorization: String,
         @Query("email") email: String
     ): Call<GetFriendsResponse>
 }
 
-val retrofit = Retrofit.Builder()
-    .baseUrl("https://27dae586598e.ngrok-free.app/") // 서버 URL 입력
-    .addConverterFactory(GsonConverterFactory.create()) // JSON 컨버터 추가
+
+// AuthInterceptor를 포함한 OkHttpClient 생성
+private val okHttpClient = OkHttpClient.Builder()
+    .addInterceptor(AuthInterceptor()) // 인터셉터(자동으로 헤더에 토큰 추가)
     .build()
-val apiService = retrofit.create(UserApiService::class.java)
+
+val retrofit = Retrofit.Builder()
+    .baseUrl("http://13.209.55.252:8080/") // 서버 URL 입력
+    .client(okHttpClient) // 인증 인터셉터 포함시키니 HTTP 클라이언트 연결
+    .addConverterFactory(ScalarsConverterFactory.create())
+    .addConverterFactory(GsonConverterFactory.create()) // JSON <-> Kotlin 객체 자동 변환
+    .build()
+val apiService =
+    retrofit.create(UserApiService::class.java) // apiService 인터페이스를 구현체로 자동 생성 (apiService.signup(), .. 등등)

--- a/frontend/app/src/main/java/com/markoala/tomoandroid/data/model/TokenResponse.kt
+++ b/frontend/app/src/main/java/com/markoala/tomoandroid/data/model/TokenResponse.kt
@@ -1,0 +1,6 @@
+package com.markoala.tomoandroid.data.model
+
+data class TokenResponse(
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/frontend/app/src/main/java/com/markoala/tomoandroid/data/repository/AuthRepository.kt
+++ b/frontend/app/src/main/java/com/markoala/tomoandroid/data/repository/AuthRepository.kt
@@ -2,7 +2,6 @@ package com.markoala.tomoandroid.data.repository
 
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
-import com.markoala.tomoandroid.auth.AuthManager
 import com.markoala.tomoandroid.data.api.apiService
 import com.markoala.tomoandroid.data.model.PostResponse
 import com.markoala.tomoandroid.data.model.UserData
@@ -14,29 +13,18 @@ import kotlin.coroutines.resumeWithException
 
 object AuthRepository {
     /**
-     * AuthManager.firebaseAuthWithGoogle 콜백을 suspend로 래핑해서 UserData 반환
+     * Firebase 현재 사용자 정보로 UserData 생성
      */
-    suspend fun firebaseSignIn(idToken: String): UserData = suspendCancellableCoroutine { cont ->
-        try {
-            AuthManager.firebaseAuthWithGoogle(idToken) { success, err ->
-                if (success) {
-                    val firebaseUser = FirebaseAuth.getInstance().currentUser
-                    if (firebaseUser != null) {
-                        val userData = UserData(
-                            uuid = firebaseUser.uid,
-                            email = firebaseUser.email ?: "",
-                            username = firebaseUser.displayName ?: ""
-                        )
-                        cont.resume(userData)
-                    } else {
-                        cont.resumeWithException(Exception("Firebase 사용자 정보가 비어있습니다."))
-                    }
-                } else {
-                    cont.resumeWithException(Exception(err ?: "Firebase 인증 실패"))
-                }
-            }
-        } catch (e: Exception) {
-            cont.resumeWithException(e)
+    fun getCurrentUserData(): UserData? {
+        val firebaseUser = FirebaseAuth.getInstance().currentUser
+        return if (firebaseUser != null) {
+            UserData(
+                uuid = firebaseUser.uid,
+                email = firebaseUser.email ?: "",
+                username = firebaseUser.displayName ?: ""
+            )
+        } else {
+            null
         }
     }
 

--- a/frontend/app/src/main/java/com/markoala/tomoandroid/data/repository/friends/FriendsRepository.kt
+++ b/frontend/app/src/main/java/com/markoala/tomoandroid/data/repository/friends/FriendsRepository.kt
@@ -3,7 +3,6 @@ package com.markoala.tomoandroid.data.repository.friends
 import android.content.Context
 import android.util.Log
 import android.widget.Toast
-import com.markoala.tomoandroid.auth.AuthManager
 import com.markoala.tomoandroid.data.api.apiService
 import com.markoala.tomoandroid.data.model.FriendData
 import com.markoala.tomoandroid.data.model.FriendSearchRequest
@@ -34,70 +33,47 @@ class FriendsRepository {
         onLoading(true)
         Log.d("FriendsRepository", "검색 상태 변경: loading = true")
 
-        // Firebase ID 토큰 가져오기
-        Log.d("FriendsRepository", "Firebase 토큰 요청 시작")
-        AuthManager.auth.currentUser?.getIdToken(true)?.addOnCompleteListener { tokenTask ->
-            if (tokenTask.isSuccessful) {
-                val firebaseToken = tokenTask.result?.token
-                Log.d("FriendsRepository", "Firebase 토큰 획득 성공")
+        // AuthInterceptor가 자동으로 토큰을 추가하므로 직접 API 호출
+        Log.d("FriendsRepository", "getFriends API 요청 생성")
 
-                if (firebaseToken != null) {
-                    // API 요청
-                    Log.d("FriendsRepository", "getFriends API 요청 생성")
+        val call = apiService.getFriends(email)
+        Log.d("FriendsRepository", "getFriends API 호출 시작")
 
-                    val call = apiService.getFriends("Bearer $firebaseToken", email)
-                    Log.d("FriendsRepository", "getFriends API 호출 시작")
+        call.enqueue(object : Callback<GetFriendsResponse> {
+            override fun onResponse(
+                call: Call<GetFriendsResponse>,
+                response: Response<GetFriendsResponse>
+            ) {
+                Log.d("FriendsRepository", "getFriends API 응답 수신")
+                Log.d("FriendsRepository", "응답 코드: ${response.code()}")
 
-                    call.enqueue(object : Callback<GetFriendsResponse> {
-                        override fun onResponse(
-                            call: Call<GetFriendsResponse>,
-                            response: Response<GetFriendsResponse>
-                        ) {
-                            Log.d("FriendsRepository", "getFriends API 응답 수신")
-                            Log.d("FriendsRepository", "응답 코드: ${response.code()}")
-
-                            onLoading(false)
-                            if (response.isSuccessful) {
-                                val result = response.body()
-                                Log.d("FriendsRepository", "응답 본문: $result")
-
-                                if (result?.success == true && result.data != null) {
-                                    Log.d(
-                                        "FriendsRepository",
-                                        "친구 검색 성공 - 찾은 친구: ${result.data.username}"
-                                    )
-                                    onSuccess(listOf(result.data)) // 단일 객체를 리스트로 변환
-                                } else {
-                                    Log.w("FriendsRepository", "친구 검색 실패")
-                                    onError(result?.message ?: "친구를 찾을 수 없습니다")
-                                }
-                            } else {
-                                Log.e("FriendsRepository", "HTTP 응답 실패 - 코드: ${response.code()}")
-                                onError("검색에 실패했습니다")
-                            }
-                        }
-
-                        override fun onFailure(call: Call<GetFriendsResponse>, t: Throwable) {
-                            Log.e("FriendsRepository", "getFriends API 요청 실패", t)
-                            onLoading(false)
-                            onError("네트워크 오류가 발생했습니다")
-                        }
-                    })
-                } else {
-                    Log.e("FriendsRepository", "Firebase 토큰이 null")
-                    onLoading(false)
-                    Toast.makeText(context, "인증 토큰을 가져올 수 없습니다", Toast.LENGTH_SHORT).show()
-                }
-            } else {
-                Log.e("FriendsRepository", "Firebase 토큰 획득 실패", tokenTask.exception)
                 onLoading(false)
-                Toast.makeText(context, "인증에 실패했습니다", Toast.LENGTH_SHORT).show()
+                if (response.isSuccessful) {
+                    val result = response.body()
+                    Log.d("FriendsRepository", "응답 본문: $result")
+
+                    if (result?.success == true && result.data != null) {
+                        Log.d(
+                            "FriendsRepository",
+                            "친구 검색 성공 - 찾은 친구: ${result.data.username}"
+                        )
+                        onSuccess(listOf(result.data)) // 단일 객체를 리스트로 변환
+                    } else {
+                        Log.w("FriendsRepository", "친구 검색 실패")
+                        onError(result?.message ?: "친구를 찾을 수 없습니다")
+                    }
+                } else {
+                    Log.e("FriendsRepository", "HTTP 응답 실패 - 코드: ${response.code()}")
+                    onError("검색에 실패했습니다")
+                }
             }
-        } ?: run {
-            Log.e("FriendsRepository", "현재 사용자가 null - 로그인되지 않음")
-            onLoading(false)
-            Toast.makeText(context, "로그인이 필요합니다", Toast.LENGTH_SHORT).show()
-        }
+
+            override fun onFailure(call: Call<GetFriendsResponse>, t: Throwable) {
+                Log.e("FriendsRepository", "getFriends API 요청 실패", t)
+                onLoading(false)
+                onError("네트워크 오류가 발생했습니다")
+            }
+        })
     }
 
     // 친구 추가 함수 (POST)
@@ -119,104 +95,69 @@ class FriendsRepository {
         onLoading(true)
         Log.d("FriendsRepository", "친구 추가 상태 변경: loading = true")
 
-        // Firebase ID 토큰 가져오기
-        Log.d("FriendsRepository", "Firebase 토큰 요청 시작")
-        AuthManager.auth.currentUser?.getIdToken(true)?.addOnCompleteListener { tokenTask ->
-            if (tokenTask.isSuccessful) {
-                val firebaseToken = tokenTask.result?.token
-                Log.d("FriendsRepository", "Firebase 토큰 획득 성공")
-                Log.d("FriendsRepository", "토큰 길이: ${firebaseToken?.length ?: 0}")
-                Log.d("FriendsRepository", "토큰 앞 20자: ${firebaseToken?.take(20) ?: "null"}...")
+        // AuthInterceptor가 자동으로 토큰을 추가하므로 직접 API 호출
+        val request = FriendSearchRequest(email = email)
+        Log.d("FriendsRepository", "API 요청 생성 - 요청 데이터: $request")
 
-                if (firebaseToken != null) {
-                    // API 요청
-                    val request = FriendSearchRequest(email = email)
-                    Log.d("FriendsRepository", "API 요청 생성 - 요청 데이터: $request")
-                    Log.d(
-                        "FriendsRepository",
-                        "Authorization 헤더: Bearer ${firebaseToken.take(20)}..."
-                    )
+        val call = apiService.postFriends(request)
+        Log.d("FriendsRepository", "API 호출 시작 - URL: ${call.request().url}")
+        Log.d("FriendsRepository", "HTTP 메소드: ${call.request().method}")
 
-                    val call = apiService.postFriends("Bearer $firebaseToken", request)
-                    Log.d("FriendsRepository", "API 호출 시작 - URL: ${call.request().url}")
-                    Log.d("FriendsRepository", "HTTP 메소드: ${call.request().method}")
-
-                    call.enqueue(object : Callback<FriendSearchResponse> {
-                        override fun onResponse(
-                            call: Call<FriendSearchResponse>,
-                            response: Response<FriendSearchResponse>
-                        ) {
-                            Log.d("FriendsRepository", "API 응답 수신")
-                            Log.d("FriendsRepository", "응답 코드: ${response.code()}")
-                            Log.d("FriendsRepository", "응답 메시지: ${response.message()}")
-                            Log.d("FriendsRepository", "응답 성공 여부: ${response.isSuccessful}")
-
-                            onLoading(false)
-                            if (response.isSuccessful) {
-                                val result = response.body()
-                                Log.d("FriendsRepository", "응답 본문: $result")
-
-                                if (result?.success == true && result.data != null) {
-                                    Log.d(
-                                        "FriendsRepository",
-                                        "친구 추가 성공 - 사용자명: ${result.data.username}, 이메일: ${result.data.email}"
-                                    )
-                                    Toast.makeText(context, "친구 추가 성공!", Toast.LENGTH_SHORT).show()
-                                    onSuccess()
-                                } else {
-                                    Log.w(
-                                        "FriendsRepository",
-                                        "친구 추가 실패 - success: ${result?.success}, data: ${result?.data}, message: ${result?.message}"
-                                    )
-                                    val errorMsg = result?.message ?: "친구 추가에 실패했습니다"
-                                    onError(errorMsg)
-                                    Toast.makeText(context, errorMsg, Toast.LENGTH_SHORT).show()
-                                }
-                            } else {
-                                Log.e(
-                                    "FriendsRepository",
-                                    "HTTP 응답 실패 - 코드: ${response.code()}, 메시지: ${response.message()}"
-                                )
-                                Log.e(
-                                    "FriendsRepository",
-                                    "에러 본문: ${response.errorBody()?.string()}"
-                                )
-                                onError("친구 추가에 실패했습니다")
-                                Toast.makeText(context, "친구 추가에 실패했습니다", Toast.LENGTH_SHORT).show()
-                            }
-                        }
-
-                        override fun onFailure(call: Call<FriendSearchResponse>, t: Throwable) {
-                            Log.e("FriendsRepository", "API 요청 완전 실패", t)
-                            Log.e("FriendsRepository", "실패 원인: ${t.javaClass.simpleName}")
-                            Log.e("FriendsRepository", "에러 메시지: ${t.message}")
-                            Log.e("FriendsRepository", "요청 URL: ${call.request().url}")
-
-                            onLoading(false)
-                            onError("네트워크 오류")
-                            Toast.makeText(context, "네트워크 오류가 발생했습니다", Toast.LENGTH_SHORT).show()
-                        }
-                    })
-                } else {
-                    Log.e("FriendsRepository", "Firebase 토큰이 null")
-                    onLoading(false)
-                    Toast.makeText(context, "인증 토큰을 가져올 수 없습니다", Toast.LENGTH_SHORT).show()
-                }
-            } else {
-                Log.e("FriendsRepository", "Firebase 토큰 획득 실패", tokenTask.exception)
-                Log.e(
-                    "FriendsRepository",
-                    "토큰 태스크 예외: ${tokenTask.exception?.javaClass?.simpleName}"
-                )
-                Log.e("FriendsRepository", "토큰 태스크 메시지: ${tokenTask.exception?.message}")
+        call.enqueue(object : Callback<FriendSearchResponse> {
+            override fun onResponse(
+                call: Call<FriendSearchResponse>,
+                response: Response<FriendSearchResponse>
+            ) {
+                Log.d("FriendsRepository", "API 응답 수신")
+                Log.d("FriendsRepository", "응답 코드: ${response.code()}")
+                Log.d("FriendsRepository", "응답 메시지: ${response.message()}")
+                Log.d("FriendsRepository", "응답 성공 여부: ${response.isSuccessful}")
 
                 onLoading(false)
-                Toast.makeText(context, "인증에 실패했습니다", Toast.LENGTH_SHORT).show()
+                if (response.isSuccessful) {
+                    val result = response.body()
+                    Log.d("FriendsRepository", "응답 본문: $result")
+
+                    if (result?.success == true && result.data != null) {
+                        Log.d(
+                            "FriendsRepository",
+                            "친구 추가 성공 - 사용자명: ${result.data.username}, 이메일: ${result.data.email}"
+                        )
+                        Toast.makeText(context, "친구 추가 성공!", Toast.LENGTH_SHORT).show()
+                        onSuccess()
+                    } else {
+                        Log.w(
+                            "FriendsRepository",
+                            "친구 추가 실패 - success: ${result?.success}, data: ${result?.data}, message: ${result?.message}"
+                        )
+                        val errorMsg = result?.message ?: "친구 추가에 실패했습니다"
+                        onError(errorMsg)
+                        Toast.makeText(context, errorMsg, Toast.LENGTH_SHORT).show()
+                    }
+                } else {
+                    Log.e(
+                        "FriendsRepository",
+                        "HTTP 응답 실패 - 코드: ${response.code()}, 메시지: ${response.message()}"
+                    )
+                    Log.e(
+                        "FriendsRepository",
+                        "에러 본문: ${response.errorBody()?.string()}"
+                    )
+                    onError("친구 추가에 실패했습니다")
+                    Toast.makeText(context, "친구 추가에 실패했습니다", Toast.LENGTH_SHORT).show()
+                }
             }
-        } ?: run {
-            Log.e("FriendsRepository", "현재 사용자가 null - 로그인되지 않음")
-            onLoading(false)
-            Toast.makeText(context, "로그인이 필요합니다", Toast.LENGTH_SHORT).show()
-        }
+
+            override fun onFailure(call: Call<FriendSearchResponse>, t: Throwable) {
+                Log.e("FriendsRepository", "API 요청 완전 실패", t)
+                Log.e("FriendsRepository", "실패 원인: ${t.javaClass.simpleName}")
+                Log.e("FriendsRepository", "에러 메시지: ${t.message}")
+                Log.e("FriendsRepository", "요청 URL: ${call.request().url}")
+
+                onLoading(false)
+                onError("네트워크 오류")
+                Toast.makeText(context, "네트워크 오류가 발생했습니다", Toast.LENGTH_SHORT).show()
+            }
+        })
     }
 }

--- a/frontend/app/src/main/java/com/markoala/tomoandroid/data/repository/friends/FriendsRepository.kt
+++ b/frontend/app/src/main/java/com/markoala/tomoandroid/data/repository/friends/FriendsRepository.kt
@@ -8,6 +8,7 @@ import com.markoala.tomoandroid.data.model.FriendData
 import com.markoala.tomoandroid.data.model.FriendSearchRequest
 import com.markoala.tomoandroid.data.model.FriendSearchResponse
 import com.markoala.tomoandroid.data.model.GetFriendsResponse
+import com.markoala.tomoandroid.utils.ErrorHandler
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -64,7 +65,12 @@ class FriendsRepository {
                     }
                 } else {
                     Log.e("FriendsRepository", "HTTP 응답 실패 - 코드: ${response.code()}")
-                    onError("검색에 실패했습니다")
+                    val errorBody = response.errorBody()?.string()
+                    Log.e("FriendsRepository", "에러 본문: $errorBody")
+
+                    // HTTP 상태 코드에 따른 구체적인 에러 메시지 생성
+                    val errorResult = ErrorHandler.handleHttpError(response.code(), errorBody)
+                    onError(errorResult.message)
                 }
             }
 
@@ -139,12 +145,13 @@ class FriendsRepository {
                         "FriendsRepository",
                         "HTTP 응답 실패 - 코드: ${response.code()}, 메시지: ${response.message()}"
                     )
-                    Log.e(
-                        "FriendsRepository",
-                        "에러 본문: ${response.errorBody()?.string()}"
-                    )
-                    onError("친구 추가에 실패했습니다")
-                    Toast.makeText(context, "친구 추가에 실패했습니다", Toast.LENGTH_SHORT).show()
+                    val errorBody = response.errorBody()?.string()
+                    Log.e("FriendsRepository", "에러 본문: $errorBody")
+
+                    // HTTP 상태 코드에 따른 구체적인 에러 메시지 생성
+                    val errorResult = ErrorHandler.handleHttpError(response.code(), errorBody)
+                    onError(errorResult.message)
+                    Toast.makeText(context, errorResult.message, Toast.LENGTH_SHORT).show()
                 }
             }
 

--- a/frontend/app/src/main/java/com/markoala/tomoandroid/ui/components/auth/GoogleSignUpButton.kt
+++ b/frontend/app/src/main/java/com/markoala/tomoandroid/ui/components/auth/GoogleSignUpButton.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.credentials.CredentialManager
 import com.markoala.tomoandroid.R
-import com.markoala.tomoandroid.data.model.UserData
+import com.markoala.tomoandroid.auth.AuthManager
 import com.markoala.tomoandroid.data.repository.AuthRepository
 import com.markoala.tomoandroid.data.repository.UserRepository
 import com.markoala.tomoandroid.ui.components.CustomText
@@ -53,7 +53,6 @@ fun GoogleSignUpButton(onSignedIn: () -> Unit) {
 
     val credentialManager = remember { CredentialManager.create(context) } // Google 계정 토큰 획득
     val coroutineScope = rememberCoroutineScope() // 버튼 클릭 시 비동기 처리용
-
 
     Button(
         modifier = Modifier
@@ -94,22 +93,40 @@ fun GoogleSignUpButton(onSignedIn: () -> Unit) {
                         throw e
                     }
 
+                    // 2) Firebase 인증 및 서버 토큰 교환
+                    AuthManager.firebaseAuthWithGoogle(idToken, context) { success, error ->
+                        if (success) {
+                            coroutineScope.launch {
+                                try {
+                                    // 3) UserData 생성 및 회원가입/로그인 처리
+                                    val userData = AuthRepository.getCurrentUserData()
 
-                    // 2) Firebase 인증 & UserData 획득
-                    val userData: UserData = AuthRepository.firebaseSignIn(idToken)
+                                    if (userData != null) {
+                                        val exists = AuthRepository.checkUserExists(userData.uuid)
+                                        if (!exists) {
+                                            AuthRepository.signUp(userData)
+                                            UserRepository.saveUserToFirestore(userData) // 최초 가입 시에만 저장
+                                            toastManager.showSuccess("회원가입 성공")
+                                        } else {
+                                            toastManager.showSuccess("로그인 성공")
+                                        }
 
-                    val exists = AuthRepository.checkUserExists(userData.uuid)
-                    if (!exists) {
-                        AuthRepository.signUp(userData)
-                        UserRepository.saveUserToFirestore(userData) // 최초 가입 시에만 저장
-                        toastManager.showSuccess("회원가입 성공")
-                    } else {
-                        toastManager.showSuccess("로그인 성공")
+                                        // 성공 콜백
+                                        onSignedIn()
+                                    } else {
+                                        Log.e("GoogleSignIn", "사용자 데이터를 가져올 수 없습니다")
+                                        toastManager.showError("사용자 데이터를 가져올 수 없습니다")
+                                    }
+                                } catch (e: Exception) {
+                                    Log.e("GoogleSignIn", "사용자 데이터 처리 실패: ${e.message}", e)
+                                    toastManager.showError("사용자 데이터 처리 실패: ${e.message}")
+                                }
+                            }
+                        } else {
+                            Log.e("GoogleSignIn", "Firebase 인증 또는 토큰 교환 실패: $error")
+                            toastManager.showError("로그인 실패: $error")
+                        }
                     }
-
-
-                    // 성공 콜백
-                    onSignedIn()
 
                 } catch (e: CancellationException) {
                     toastManager.showError("작업 취소됨: ${e.message}")

--- a/frontend/app/src/main/java/com/markoala/tomoandroid/ui/main/friends/AddFriendsScreen.kt
+++ b/frontend/app/src/main/java/com/markoala/tomoandroid/ui/main/friends/AddFriendsScreen.kt
@@ -38,7 +38,6 @@ import com.markoala.tomoandroid.ui.components.CustomTextType
 import com.markoala.tomoandroid.ui.components.DashedBorderBox
 import com.markoala.tomoandroid.ui.components.LocalToastManager
 import com.markoala.tomoandroid.ui.theme.CustomColor
-import com.markoala.tomoandroid.utils.ErrorHandler
 
 @Composable
 fun AddFriendsScreen(
@@ -82,10 +81,19 @@ fun AddFriendsScreen(
             onError = { error ->
                 searchResults = emptyList()
                 errorMessage = error
-
-                // ErrorHandler를 사용하여 에러 처리
-                val errorResult = ErrorHandler.handleFriendSearchError(error)
-                ErrorHandler.showToast(toastManager, errorResult)
+                // HTTP 상태 코드에 따른 에러 처리는 Repository에서 이미 수행됨
+                // 추가로 UI에서 에러 타입을 구분하려면 ErrorHandler 사용
+                if (error.contains("해당 이메일로 등록된 사용자가 없습니다") ||
+                    error.contains("찾을 수 없습니다")
+                ) {
+                    toastManager.showInfo(error)
+                } else if (error.contains("인증") || error.contains("로그인")) {
+                    toastManager.showError(error)
+                } else if (error.contains("입력") || error.contains("잘못된")) {
+                    toastManager.showWarning(error)
+                } else {
+                    toastManager.showError(error)
+                }
             }
         )
     }
@@ -105,10 +113,19 @@ fun AddFriendsScreen(
             },
             onError = { error ->
                 errorMessage = error
-
-                // ErrorHandler를 사용하여 에러 처리
-                val errorResult = ErrorHandler.handleFriendAddError(error)
-                ErrorHandler.showToast(toastManager, errorResult)
+                // HTTP 상태 코드에 따른 에러 처리는 Repository에서 이미 수행됨
+                // 추가로 UI에서 에러 타입을 구분하려면 ErrorHandler 사용
+                if (error.contains("이미 친구") || error.contains("해당 이메일로 등록된 사용자가 없습니다")) {
+                    toastManager.showInfo(error)
+                } else if (error.contains("자신을")) {
+                    toastManager.showWarning(error)
+                } else if (error.contains("인증") || error.contains("로그인")) {
+                    toastManager.showError(error)
+                } else if (error.contains("입력") || error.contains("잘못된")) {
+                    toastManager.showWarning(error)
+                } else {
+                    toastManager.showError(error)
+                }
             }
         )
     }

--- a/frontend/app/src/main/java/com/markoala/tomoandroid/utils/ErrorHandler.kt
+++ b/frontend/app/src/main/java/com/markoala/tomoandroid/utils/ErrorHandler.kt
@@ -83,6 +83,65 @@ object ErrorHandler {
     }
 
     /**
+     * HTTP 상태 코드에 따른 에러를 처리합니다.
+     */
+    fun handleHttpError(statusCode: Int, errorBody: String? = null): ErrorResult {
+        return when (statusCode) {
+            400 -> {
+                ErrorResult("잘못된 요청입니다. 입력 정보를 확인해주세요.", ToastType.WARNING)
+            }
+
+            401 -> {
+                ErrorResult("인증이 필요합니다. 다시 로그인해주세요.", ToastType.ERROR)
+            }
+
+            403 -> {
+                ErrorResult("접근 권한이 없습니다.", ToastType.ERROR)
+            }
+
+            404 -> {
+                ErrorResult("해당 이메일로 등록된 사용자가 없습니다.", ToastType.INFO)
+            }
+
+            409 -> {
+                ErrorResult("이미 친구로 등록된 사용자입니다.", ToastType.INFO)
+            }
+
+            422 -> {
+                ErrorResult("입력한 정보가 올바르지 않습니다.", ToastType.WARNING)
+            }
+
+            429 -> {
+                ErrorResult("요청이 너무 많습니다. 잠시 후 다시 시도해주세요.", ToastType.WARNING)
+            }
+
+            500 -> {
+                ErrorResult("서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", ToastType.ERROR)
+            }
+
+            502 -> {
+                ErrorResult("서버 연결에 문제가 있습니다. 잠시 후 다시 시도해주세요.", ToastType.ERROR)
+            }
+
+            503 -> {
+                ErrorResult("서버가 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도해주세요.", ToastType.ERROR)
+            }
+
+            504 -> {
+                ErrorResult("서버 응답 시간이 초과되었습니다. 다시 시도해주세요.", ToastType.ERROR)
+            }
+
+            in 500..599 -> {
+                ErrorResult("서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", ToastType.ERROR)
+            }
+
+            else -> {
+                ErrorResult("알 수 없는 오류가 발생했습니다. (코드: $statusCode)", ToastType.ERROR)
+            }
+        }
+    }
+
+    /**
      * ErrorResult를 기반으로 ToastManager에 적절한 토스트를 표시합니다.
      */
     fun showToast(toastManager: ToastManager, errorResult: ErrorResult) {

--- a/frontend/app/src/main/java/com/markoala/tomoandroid/utils/auth/TokenManager.kt
+++ b/frontend/app/src/main/java/com/markoala/tomoandroid/utils/auth/TokenManager.kt
@@ -1,0 +1,44 @@
+package com.markoala.tomoandroid.utils.auth
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+class TokenManager(context: Context) {
+    private val sharedPreferences: SharedPreferences =
+        context.getSharedPreferences( // sharedPreferences 로컷 저장소 생성
+            "secure_prefs", // "secure_prefs"라는 이름으로 생성
+            Context.MODE_PRIVATE // 앱 내부에서만 접근
+        )
+
+    companion object { // static과 같은개념
+        private const val ACCESS_TOKEN_KEY = "access_token"
+        private const val REFRESH_TOKEN_KEY = "refresh_token"
+    }
+
+    fun saveTokens(accessToken: String, refreshToken: String) {
+        sharedPreferences.edit { // 확장 함수를 이용해 key-value 쌍으로 저장
+            putString(ACCESS_TOKEN_KEY, accessToken)
+            putString(REFRESH_TOKEN_KEY, refreshToken)
+        }
+    }
+
+    fun getAccessToken(): String? { // 저장된 토큰 불러오기
+        return sharedPreferences.getString(ACCESS_TOKEN_KEY, null)
+    }
+
+    fun getRefreshToken(): String? { // 저장된 토큰 불러오기
+        return sharedPreferences.getString(REFRESH_TOKEN_KEY, null)
+    }
+
+    fun clearTokens() { // 로그아웃 시 호출하여 저장된 모든 토큰 제거
+        sharedPreferences.edit {
+            remove(ACCESS_TOKEN_KEY)
+            remove(REFRESH_TOKEN_KEY)
+        }
+    }
+
+    fun hasValidTokens(): Boolean { // 토큰 유효성 검사 (두 토큰이 모두 존재하는지)
+        return getAccessToken() != null && getRefreshToken() != null
+    }
+}

--- a/frontend/app/src/main/res/xml/network_security_config.xml
+++ b/frontend/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">13.209.55.252</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## 작업 내용
- Firebase IdToken -> JWT Token  변환 API 추가 
- API 요청헤더에 토큰 적용 인터셉터 추가 및 적용
- 배포 URL HTTP 임시 허용 작업
- plain/text 컨버터, 로컬 저장소(Shared-Preference), okHttp 의존성 추가
- jwt 토큰 로컬 저장소 추가
- jwt token 받아오는 API 적용 및 저장, 유효성 추가
- 앱 시작지점 앱 토큰 유효성 검사 및 자동 로그인 추가
- 친구 추가 및 조회 API 연동 완료(헤더포함)
- 친구 추가 및 조회 토스트 서버 상태 코드에 따라 대응


## 백엔드 참고 내용
- 토큰 변환 API 수정 필요( 응답 헤더 -> 응답 바디로 토큰 전달, 바디 메시지 JSON 타입으로 변경하거나 없애야 함)
- 배포 URL HTTPS 허용 필요

## 스크린샷

### 친구 추가 및 조회 토스트 메시지

<img width=25% alt="Screenshot_20251007_000202" src="https://github.com/user-attachments/assets/8ba264ae-0212-4c9a-9d0d-805805e53544" />
<img width=25%alt="Screenshot_20251007_000212" src="https://github.com/user-attachments/assets/3a8c2afc-8a99-4612-8081-be674dba8412" />
<img width=25% alt="Screenshot_20251007_000216" src="https://github.com/user-attachments/assets/b7893b49-d064-4fb2-946b-248bd74c691f" />

### 앱 자동 로그인

- 앱 진입 점에서 토큰 valid 확인 후 자동 로그인이 되는 모습

https://github.com/user-attachments/assets/f122622f-de0a-45aa-9320-c7cc5bd3f261




