### PR TITLE
fix : API 피드백 반영 

### DIFF
--- a/backend/src/main/java/com/example/tomo/Friends/FriendController.java
+++ b/backend/src/main/java/com/example/tomo/Friends/FriendController.java
@@ -1,6 +1,5 @@
 package com.example.tomo.Friends;
 
-import com.example.tomo.Friends.dtos.ResponseGetFriendsDto;
 import com.example.tomo.Friends.dtos.ResponseFriendDetailDto;
 import com.example.tomo.global.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,16 +22,7 @@ public class FriendController {
         this.friendService = friendService;
     }
 
-    @Operation(summary = "내 친구 목록 조회", description = "로그인된 사용자의 친구 목록을 반환합니다")
-    @GetMapping("/friends/list")
-    public ResponseEntity<ApiResponse<List<ResponseGetFriendsDto>>> getMyFriends() {
-        try {
-            return ResponseEntity.ok(ApiResponse.success(friendService.getFriends(), "성공"));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(ApiResponse.failure("로그인된 사용자가 아닙니다"));
-        }
-    }
+
 
     @Operation(summary = "친구 상세 정보 조회", description = "로그인된 사용자의 친구 상세 정보를 반환합니다")
     @GetMapping("/friends/detail")

--- a/backend/src/main/java/com/example/tomo/Friends/FriendController.java
+++ b/backend/src/main/java/com/example/tomo/Friends/FriendController.java
@@ -24,8 +24,8 @@ public class FriendController {
 
 
 
-    @Operation(summary = "친구 상세 정보 조회", description = "로그인된 사용자의 친구 상세 정보를 반환합니다")
-    @GetMapping("/friends/detail")
+    @Operation(summary = "친구 목록 조회", description = "사용자의 친구 목록을 반환합니다")
+    @GetMapping("/friends/list")
     public ResponseEntity<ApiResponse<List<ResponseFriendDetailDto>>> getFriendDetails() {
         try {
             return ResponseEntity.ok().body(ApiResponse.success(friendService.getDetailFriends(), "성공"));

--- a/backend/src/main/java/com/example/tomo/Friends/FriendService.java
+++ b/backend/src/main/java/com/example/tomo/Friends/FriendService.java
@@ -25,25 +25,6 @@ public class FriendService {
         this.userRepository = userRepository;
     }
 
-    // 친구 목록 조회하기
-    // 액세스 토큰을 받아와야 함
-    public List<ResponseGetFriendsDto> getFriends() {
-        // 액세스 토큰으로는 요청 인증만 하고, 다른 사용자 인증 프로세스가 요구됨 아이디를 받아야 겠지?
-        Long userId =1L;
-        // 근데 병찬이가 보내주면 String으로 올텐데
-
-        User existUser = userRepository.findById(userId)
-                .orElseThrow(()->new IllegalArgumentException("친구 상세 정보 출력 중 사용자 인증이 되지 않았습니다. 로그인 부탁"));
-
-        List<Long> idList= friendRepository.getFriends(existUser.getId());
-
-        return idList.stream()
-                .map(userRepository::findById)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .map(user -> new ResponseGetFriendsDto(user.getUsername()))
-                .collect(Collectors.toList());
-    }
 
     // 친구 상세 정보 출력하기
     public List<ResponseFriendDetailDto> getDetailFriends(){

--- a/backend/src/main/java/com/example/tomo/Friends/FriendService.java
+++ b/backend/src/main/java/com/example/tomo/Friends/FriendService.java
@@ -2,14 +2,12 @@ package com.example.tomo.Friends;
 
 import com.example.tomo.Friends.dtos.FriendCalculatedDto;
 import com.example.tomo.Friends.dtos.ResponseFriendDetailDto;
-import com.example.tomo.Friends.dtos.ResponseGetFriendsDto;
 import com.example.tomo.Users.User;
 import com.example.tomo.Users.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -47,10 +45,15 @@ public class FriendService {
                             .map(User::getUsername)
                             .orElse("알수 없음");
 
+                    String email = userRepository.findById(dto.getUserId())
+                            .map(User::getEmail)
+                            .orElse("알 수 없음");
+
                     System.out.println("friendName = " + friendName);
 
                     return new ResponseFriendDetailDto(
                             friendName,
+                            email,
                             dto.getFriendship(),
                             dto.getFriendPeriod()
                     );

--- a/backend/src/main/java/com/example/tomo/Friends/dtos/ResponseFriendDetailDto.java
+++ b/backend/src/main/java/com/example/tomo/Friends/dtos/ResponseFriendDetailDto.java
@@ -12,11 +12,13 @@ import lombok.Setter;
 public class ResponseFriendDetailDto {
 
     private String username;
+    private String email;
     private Double friendship;
     private String createdAt;
 
-    public ResponseFriendDetailDto(String username, Double friendship, String createdAt) {
+    public ResponseFriendDetailDto(String username, String email, Double friendship, String createdAt) {
         this.username = username;
+        this.email = email;
         this.friendship = friendship;
         this.createdAt = createdAt;
     }

--- a/backend/src/main/java/com/example/tomo/Moim/MoimController.java
+++ b/backend/src/main/java/com/example/tomo/Moim/MoimController.java
@@ -55,8 +55,8 @@ public class MoimController {
     }
 
     @Operation(summary = "내 모임 리스트 조회", description = "로그인한 사용자가 속한 모든 모임 정보를 조회합니다")
-    @GetMapping("/moims/mine")
-    public ResponseEntity<List<getMoimResponseDTO>> getAllMoims() {
-        return ResponseEntity.ok().body(moimService.getMoimList());
+    @GetMapping("/moims/list")
+    public ResponseEntity<ApiResponse<List<getMoimResponseDTO>>> getAllMoims() {
+        return ResponseEntity.ok().body(ApiResponse.success(moimService.getMoimList(),"모임 조회 성공"));
     }
 }

--- a/backend/src/main/java/com/example/tomo/Moim/MoimService.java
+++ b/backend/src/main/java/com/example/tomo/Moim/MoimService.java
@@ -37,15 +37,15 @@ public class MoimService {
             throw new DuplicatedException("이미 존재하는 모임 이름입니다.");
         }
 
-        Moim moim = new Moim(dto.getMoimName(), dto.getDescription());
+        Moim moim = new Moim(dto.getMoimName(), dto.getDescription()); // 일단 생성자도 변경해야 해서 그대로 두기
         moimRepository.save(moim);
 
-        for (String userName : dto.getUserNames()) {
+        for (String email : dto.getEmails()) {
 
-            Optional<User> user = userRepository.findByUsername(userName);
+            Optional<User> user = userRepository.findByEmail(email);
 
             if(user.isEmpty()){
-                throw new EntityNotFoundException("해당 이름의 사용자가 존재하지 않습니다");
+                throw new EntityNotFoundException("해당 이메일의 사용자가 존재하지 않습니다");
             }
 
             Moim_people moim_people = new Moim_people(moim, user.get());

--- a/backend/src/main/java/com/example/tomo/Moim/dtos/addMoimRequestDto.java
+++ b/backend/src/main/java/com/example/tomo/Moim/dtos/addMoimRequestDto.java
@@ -11,5 +11,5 @@ public class addMoimRequestDto {
 
     private String moimName;
     private String description; // 병찬이가 필요없대
-    private List<String> userNames; // 사용자 이름 , 이메일로
+    private List<String> emails; // 사용자 이름 , 이메일로
 }

--- a/backend/src/main/java/com/example/tomo/Promise/Promise.java
+++ b/backend/src/main/java/com/example/tomo/Promise/Promise.java
@@ -4,9 +4,7 @@ import com.example.tomo.Moim.Moim;
 import jakarta.persistence.*;
 import lombok.Getter;
 
-import java.sql.Time;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Entity
@@ -22,7 +20,7 @@ public class Promise {
     @JoinColumn(name ="moim_id")
     private Moim moim;
 
-    private String place;
+    private String location;
 
     private LocalTime promiseTime;
     private LocalDate promiseDate;
@@ -30,9 +28,9 @@ public class Promise {
 
     public Promise() {}
 
-    public Promise(String promiseName, String place,
+    public Promise(String promiseName, String location,
                    LocalTime promiseTime, LocalDate promiseDate) {
-        this.place = place;
+        this.location = location;
         this.promiseName = promiseName;
         this.promiseDate = promiseDate;
         this.promiseTime = promiseTime;

--- a/backend/src/main/java/com/example/tomo/Promise/PromiseRepository.java
+++ b/backend/src/main/java/com/example/tomo/Promise/PromiseRepository.java
@@ -16,7 +16,7 @@ public interface PromiseRepository extends JpaRepository<Promise, Long> {
     boolean existsByPromiseName(String name);
     boolean existsByPromiseDateAndPromiseTime( LocalDate date,LocalTime time);
 
-    @Query("SELECT new com.example.tomo.Promise.ResponseGetPromiseDto(p.promiseName, p.promiseDate, p.promiseTime, p.place" +
+    @Query("SELECT new com.example.tomo.Promise.ResponseGetPromiseDto(p.promiseName, p.promiseDate, p.promiseTime, p.location" +
             ") FROM Promise p WHERE p.moim.id =:moim_id")
     List<ResponseGetPromiseDto> findByMoimId(@Param("moim_id") Long moim_id);
 

--- a/backend/src/main/java/com/example/tomo/Promise/PromiseService.java
+++ b/backend/src/main/java/com/example/tomo/Promise/PromiseService.java
@@ -48,7 +48,7 @@ public class PromiseService {
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 약속입니다"));
 
         return new ResponseGetPromiseDto(promise.getPromiseName(),promise.getPromiseDate(),
-        promise.getPromiseTime(),promise.getPlace());
+        promise.getPromiseTime(),promise.getLocation());
 
 
     }

--- a/backend/src/main/java/com/example/tomo/Promise/ResponseGetPromiseDto.java
+++ b/backend/src/main/java/com/example/tomo/Promise/ResponseGetPromiseDto.java
@@ -1,5 +1,6 @@
 package com.example.tomo.Promise;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,7 +17,9 @@ public class ResponseGetPromiseDto {
 
     private String promiseName;
     private LocalDate promiseDate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss", timezone = "Asia/Seoul")
     private LocalTime promiseTime;
-    private String place;
+    private String location;
 
 }

--- a/backend/src/main/java/com/example/tomo/firebase/ResponseFirebaseLoginDto.java
+++ b/backend/src/main/java/com/example/tomo/firebase/ResponseFirebaseLoginDto.java
@@ -1,0 +1,11 @@
+package com.example.tomo.firebase;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ResponseFirebaseLoginDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/backend/src/main/java/com/example/tomo/global/SecurityConfig.java
+++ b/backend/src/main/java/com/example/tomo/global/SecurityConfig.java
@@ -2,6 +2,9 @@ package com.example.tomo.global;
 
 import com.example.tomo.firebase.FirebaseAuthenticationFilter;
 import com.example.tomo.jwt.JwtAuthenticationFilter;
+import org.apache.catalina.connector.Connector;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -39,7 +42,8 @@ public class SecurityConfig {
         http
                 .securityMatcher("/public/**")
                 .csrf(CsrfConfigurer::disable)
-                .cors(Customizer.withDefaults())
+                .cors(Customizer.withDefaults());
+        http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/protected/**","/swagger-ui/**").permitAll() // Firebase 체인 전용
                         .anyRequest().authenticated()
@@ -48,5 +52,19 @@ public class SecurityConfig {
 
 
         return http.build();
+    }
+
+    @Bean
+    public WebServerFactoryCustomizer<TomcatServletWebServerFactory> servletContainer() {
+        return factory -> factory.addAdditionalTomcatConnectors(httpToHttpsRedirectConnector());
+    }
+
+    private Connector httpToHttpsRedirectConnector() {
+        Connector connector = new Connector(TomcatServletWebServerFactory.DEFAULT_PROTOCOL);
+        connector.setScheme("http");
+        connector.setPort(8080); // HTTP port
+        connector.setSecure(false);
+        connector.setRedirectPort(8443); // HTTPS port
+        return connector;
     }
 }

--- a/backend/src/main/java/com/example/tomo/global/SecurityConfig.java
+++ b/backend/src/main/java/com/example/tomo/global/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults());
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/protected/**","/swagger-ui/**").permitAll() // Firebase 체인 전용
+                        .requestMatchers("/api/protected/**","/swagger-ui/**","public/signup").permitAll() // Firebase 체인 전용
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);

--- a/backend/src/main/java/com/example/tomo/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/tomo/jwt/JwtAuthenticationFilter.java
@@ -44,6 +44,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
             return;
         }
+        if (path.startsWith("/public/signup")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
         try {
             if (header != null && header.startsWith("Bearer ")) {


### PR DESCRIPTION

<img width="1032" height="572" alt="image" src="https://github.com/user-attachments/assets/77691cc4-90b0-4111-b08d-348436466ef8" />

### /api/protected/user 성공 시 토큰을 ResponseBody로 성공적으로 전달 

<img width="1032" height="749" alt="image" src="https://github.com/user-attachments/assets/128154b3-3905-43ef-bb7d-6a7df461727a" />

### 위 API로 받은 토큰으로 친구 목록 조회 성공(이메일 필드를 추가)

<img width="1032" height="749" alt="image" src="https://github.com/user-attachments/assets/3605dc01-9b36-4b34-8c56-af3a7c3df73d" />

### 모임 목록 조회는 moims/mine -> moims/list로 수정함

<img width="1032" height="749" alt="image" src="https://github.com/user-attachments/assets/8d96a8eb-5f84-439c-ad84-0411d4bd0047" />

### 모임 생성 시 이메일을 전달 받도록 수정, description은 생각보다.. 얽혀 있는게 많아서 추후 수정

<img width="1032" height="749" alt="image" src="https://github.com/user-attachments/assets/6dc3e429-ebb1-48de-b5ac-40a347c62d85" />

### 회원가입은 jwt 토큰 없이도 가능하도록 수정 완료

### 추후 할일
- 다시 배포하기
- https 환경에서 잘 작동하는지 확인하기(현재 세팅해둔 방식은 http -> https로 변경해서 요청을 받도록)
- 계정 삭제, 친구 삭제 만들기 

