### PR TITLE
fix : 예외처리로 서버 오류 출력 방지

### DIFF
--- a/backend/src/main/java/com/example/tomo/Friends/FriendController.java
+++ b/backend/src/main/java/com/example/tomo/Friends/FriendController.java
@@ -55,7 +55,8 @@ public class FriendController {
             description = "이메일로 친구 정보를 조회합니다.",
             responses = {
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "친구 조회 완료"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "친구를 찾을 수 없음")
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "친구를 찾을 수 없음"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "정확한 이메일, 초대코드 입력")
             }
     )
     @GetMapping("/friends")
@@ -64,6 +65,8 @@ public class FriendController {
             return ResponseEntity.ok(ApiResponse.success(userService.getUserInfo(query), "친구 조회 완료"));
         } catch (EntityNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure(e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.failure(e.getMessage()));
         }
     }
     @GetMapping("/friends/detail")


### PR DESCRIPTION
## QA 내용 
### 친구 조회시 올바르지 않은 이메일 또는 초대코드 입력 시 서버 에러가 반환된다. 

1. 요청 (Request) 시 초대코드를 제대로 입력하지 않았을 경우

```
curl -X GET "http://localhost:8080/public/friends?query=TOMO-SH1" \
-H "Authorization: Bearer eyJhbGciOiJIUz...JJcvvA"
```

결과 (Response)
서버가 유효한 inviteCode를 찾지 못해 오류 메시지를 반환했습니다.


```JSON
{
  "success": false,
  "message": "email 또는 inviteCode 중 하나는 반드시 필요합니다.",
  "data": null
}
```

2. 성공한 요청 (Case 2: Success) query 파라미터에 올바른 코드(TOMO-SHw1)를 전송했습니다.

```
curl -X GET "http://localhost:8080/public/friends?query=TOMO-SHw1" \
-H "Authorization: Bearer eyJhbGciOiJIQ...JJcvvA"

```
결과 (Response)
서버가 코드를 성공적으로 인식하고 해당 친구의 정보를 반환했습니다.


``` JSON
{
  "success": true,
  "message": "친구 조회 완료",
  "data": {
    "username": "이병찬",
    "email": "chris212375@gmail.com"
  }
}
```